### PR TITLE
Made getFaviconTag() more accurate

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -45,7 +45,7 @@
 		var links = document.getElementsByTagName('link');
 		
 		for(var i=0, len=links.length; i < len; i++) {
-			if (links[i].getAttribute('rel') === 'icon') {
+			if ((links[i].getAttribute('rel') || '').match(/\bicon\b/)) {
 				return links[i];
 			}
 		}


### PR DESCRIPTION
The `rel` attribute can consist of space-separated multiple values.  For example, the following code couldn’t be detected in the previous code:

``` html
<link rel="shortcut icon" href="/favicon.ico" />
```
