### PR TITLE
Handle dynamic document titles

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -134,15 +134,16 @@
 	};
 
 	var updateTitle = function(num) {
-        if (options.fallback) {
-            var numText = num > 0 ? '('+num+') ' : '';
-            if (options.fallbackMethod === 'static') {
-                document.title = numText + originalTitle;
-            } else if (options.fallbackMethod === 'dynamic') {
-                titleSplit = document.title.split(titleRegEx);
-                document.title = numText + titleSplit.slice(-1);
+            if (options.fallback) {
+                var titleSplit,
+                    numText = num > 0 ? '('+num+') ' : '';
+                if (options.fallbackMethod === 'static') {
+                    document.title = numText + originalTitle;
+                } else if (options.fallbackMethod === 'dynamic') {
+                    titleSplit = document.title.split(titleRegEx);
+                    document.title = numText + titleSplit.slice(-1);
+                }
             }
-        }
 	};
 
 	var drawBubble = function(context, num, colour) {


### PR DESCRIPTION
Adds `fallbackMethod` option for dynamic document titles 
- `static` is the traditional behavior based on the original document title
- `dynamic` uses a regex to replace the title in the event the original document title changed since the script loaded
