### PR TITLE
Force title fallback for IE

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -33,6 +33,7 @@
 	}());
 
 	var browser = {
+		ie: ua('msie'),
 		chrome: ua('chrome'),
 		webkit: ua('chrome') || ua('safari'),
 		safari: ua('safari') && !ua('chrome'),
@@ -104,7 +105,7 @@
 	var drawFavicon = function(num, colour) {
 
 		// fallback to updating the browser title if unsupported
-		if (!getCanvas().getContext || browser.safari || options.fallback === 'force') {
+		if (!getCanvas().getContext || browser.ie || browser.safari || options.fallback === 'force') {
 			return updateTitle(num);
 		}
 		


### PR DESCRIPTION
In Internet Explorer 9 (9.0.8112.16421) fallback to title updating isn't happening since it has the getContext function on it's canvas element and passes the [fallback check](https://github.com/tommoor/tinycon/blob/master/tinycon.js#L107), but later fails to run the [onload callback](https://github.com/tommoor/tinycon/blob/master/tinycon.js#L117).

This adds explicit fallback to title update for IE.
