### PR TITLE
Doesn't work contains another "icon" string in link rel on Chrome.

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -62,7 +62,7 @@
 		
 		for(var i=0, len=links.length; i < len; i++) {
 			var exists = (typeof(links[i]) !== 'undefined');
-			if (exists && links[i].getAttribute('rel') === 'icon') {
+			if (exists && (links[i].getAttribute('rel') || '').match(/\bicon\b/)) {
 				head.removeChild(links[i]);
 			}
 		}


### PR DESCRIPTION
Chrome couldn't update a favicon.
ex) <link rel="shortcut icon" ...

It seems that link tag wasn't remove.
Because removeFaviconTag method compare "icon".

removeFaviconTag method compare

``` javascript
links[i].getAttribute('rel') === 'icon'
```

But getFaviconTag method compare string as regex.
getFaviconTag method compare

``` javascript
(links[i].getAttribute('rel') || '').match(/\bicon\b/)
```
