### PR TITLE
Fixed double-printing the favicon

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -122,9 +122,8 @@
 			// clear canvas
 			context.clearRect(0, 0, size, size);
 
-			// draw original favicon fallback to 16x16, then overwrite with 32x32 if possible
-			context.drawImage(faviconImage, 0, 0, 16, 16, 0, 0, size, size);
-			if (!browser.mozilla) context.drawImage(faviconImage, 0, 0, 32, 32, 0, 0, size, size);
+			// draw the favicon
+			context.drawImage(faviconImage, 0, 0, faviconImage.width, faviconImage.height, 0, 0, size, size);
 
 			// draw bubble over the top
 			if ((label + '').length > 0) drawBubble(context, label, colour);


### PR DESCRIPTION
The issue:

![screen shot 2013-10-11 at 1 28 12 pm](https://f.cloud.github.com/assets/935744/1314050/9a6b19fc-3268-11e3-80b6-be8ee8b83bc0.png)

I'm not sure why were you doing the double drawImage only if `!browser.mozilla`. Was that trying to fix an edge case that I'm not contemplating? Cheers.
