### PR TITLE
Optionally set crossOrigin = 'anonymous'

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -24,6 +24,7 @@
 		colour: '#ffffff',
 		background: '#F03D25',
 		fallback: true,
+		crossOrigin: true,
 		abbreviate: true
 	};
 
@@ -135,7 +136,7 @@
 
 		// allow cross origin resource requests if the image is not a data:uri
 		// as detailed here: https://github.com/mrdoob/three.js/issues/1305
-		if (!src.match(/^data/)) {
+		if (!src.match(/^data/) && options.crossOrigin) {
 			faviconImage.crossOrigin = 'anonymous';
 		}
 


### PR DESCRIPTION
crossOrigin = 'anonymous' will not send cookies with requests. This
can, for example, cause a login redirect which results in the cross
origin error the code tried to avoid in the first place.
