### PR TITLE
Skip no-op drawFavicon() calls

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -9,6 +9,8 @@
 (function(){
 
 	var Tinycon = {};
+	var currentLabel = null;
+	var currentColour = null;
 	var currentFavicon = null;
 	var originalFavicon = null;
 	var originalTitle = document.title;
@@ -107,6 +109,12 @@
 	};
 
 	var drawFavicon = function(label, colour) {
+		if (currentLabel === label && currentColour === colour) {
+			// Same label and color, return.
+			return;
+		}
+		currentLabel = label;
+		currentColour = colour;
 
 		// fallback to updating the browser title if unsupported
 		if (!getCanvas().getContext || browser.ie || browser.safari || options.fallback === 'force') {


### PR DESCRIPTION
drawFavicon normally results in an HTTP request for favicon.ico.
Depending on use this can lead to significant traffic.
