### PR TITLE
Chrome browsers with nonstandard zoom report fractional devicePixelRatio.

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -14,7 +14,8 @@
 	var faviconImage = null;
 	var canvas = null;
 	var options = {};
-	var r = window.devicePixelRatio || 1;
+	// Chrome browsers with nonstandard zoom report fractional devicePixelRatio.
+	var r = Math.ceil(window.devicePixelRatio) || 1;
 	var size = 16 * r;
 	var defaults = {
 		width: 7,


### PR DESCRIPTION
Fractional pixel values cause drawing artifacts with text.
Tested on a retina display (rounds up to 2) and a standard
display (stays at 1).

Before:
![screen shot 2014-09-12 at 8 38 55 am](https://cloud.githubusercontent.com/assets/15394/4252356/71fd281c-3a95-11e4-9424-6ecbb08d104a.png)

After:
![screen shot 2014-09-12 at 8 37 41 am](https://cloud.githubusercontent.com/assets/15394/4252361/79b1ee58-3a95-11e4-8cc2-3d7468bb1ef5.png)
