### PR TITLE
Ensure we have a URL to set before setting it

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -92,13 +92,15 @@
 	};
 
 	var setFaviconTag = function(url){
-		removeFaviconTag();
-
-		var link = document.createElement('link');
-		link.type = 'image/x-icon';
-		link.rel = 'icon';
-		link.href = url;
-		document.getElementsByTagName('head')[0].appendChild(link);
+		if(url){
+			removeFaviconTag();
+	
+			var link = document.createElement('link');
+			link.type = 'image/x-icon';
+			link.rel = 'icon';
+			link.href = url;
+			document.getElementsByTagName('head')[0].appendChild(link);
+		}
 	};
 
 	var log = function(message){


### PR DESCRIPTION
Without this, I ran into an error where my code tried to call `Tinycon.reset()` before Tinycon had save the `orginalFavicon` which caused it to try and set the favicon URL to `null`