### PR TITLE
Remove trailing comma, there are no other keys.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "url": "git://github.com/tommoor/tinycon.git"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
+    "grunt": "~0.4.5"
   }
 }


### PR DESCRIPTION
This should make the package.json valid JSON so it can actually be published and used a dependency in projects (by referencing the repository as version)