### PR TITLE
Restore the original Favicon on reset

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -74,7 +74,10 @@
 
 		if (!originalFavicon || !currentFavicon) {
 			var tag = getFaviconTag();
-			originalFavicon = currentFavicon = tag ? tag.getAttribute('href') : '/favicon.ico';
+			currentFavicon = tag ? tag.getAttribute('href') : '/favicon.ico';
+			if (!originalFavicon) {
+				originalFavicon = currentFavicon;
+			}
 		}
 
 		return currentFavicon;

--- a/tinycon.js
+++ b/tinycon.js
@@ -271,6 +271,7 @@
 	};
 
 	Tinycon.reset = function(){
+		currentFavicon = originalFavicon;
 		setFaviconTag(originalFavicon);
 	};
 


### PR DESCRIPTION
I suppose it's intended that way. Why else would there be a currentFavicon AND an originalFavicon variable?