### PR TITLE
do not match apple-icon in rel matcher

### DIFF
--- a/tinycon.js
+++ b/tinycon.js
@@ -49,7 +49,7 @@
     var links = document.getElementsByTagName('link');
 
     for(var i=0, len=links.length; i < len; i++) {
-      if ((links[i].getAttribute('rel') || '').match(/\bicon\b/i)) {
+      if ((links[i].getAttribute('rel') || '').match(/\b(^| )icon\b/i)) {
         return links[i];
       }
     }
@@ -63,7 +63,7 @@
 
     for(var i=0, len=links.length; i < len; i++) {
       var exists = (typeof(links[i]) !== 'undefined');
-      if (exists && (links[i].getAttribute('rel') || '').match(/\bicon\b/i)) {
+      if (exists && (links[i].getAttribute('rel') || '').match(/\b(^| )icon\b/i)) {
         links[i].parentNode.removeChild(links[i]);
       }
     }


### PR DESCRIPTION
The previous matcher to find the link-element did look for everything containing the word 'icon'. Also apple's <link rel="apple-touch-icon" ...> was matched and got removed, or used as faviconTag (depending on the link elements' order).
The new matcher does not allow word 'icon' starting with hyphen anymore. 